### PR TITLE
feat: Add unit test for WinReg library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,10 @@ install(
     TARGETS WinReg DESTINATION ${LIB_INSTALL_DIR}
     INCLUDES ${HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}
 )
+
+if(UNIT_TEST)
+    add_executable(UnitTest WinReg/WinRegTest.cpp)
+    target_link_libraries(UnitTest PRIVATE WinReg)
+
+    configure_file(${CMAKE_SOURCE_DIR}/WinReg/GioTest.reg ${CMAKE_CURRENT_BINARY_DIR}/GioTest.reg COPYONLY)
+endif()


### PR DESCRIPTION
Add a unit test for the WinReg library to ensure its functionality is correct. The unit test is implemented in the `WinRegTest.cpp` file and linked with the `WinReg` library. Additionally, a sample registry file (`GioTest.reg`) is copied to the build directory.